### PR TITLE
Added support for updating DOM className of elements via Element.attr

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -309,6 +309,7 @@
             "arrow-end": none,
             "arrow-start": none,
             blur: 0,
+            "class": "",
             "clip-rect": "0 0 1e9 1e9",
             "clip-path": E,
             cursor: "default",

--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -501,6 +501,10 @@ window.Raphael && window.Raphael.svg && function(R) {
                         }
                         node.titleNode = pn;
                         break;
+                    case "class":
+                        value = value || E;
+                        node.setAttribute('class', o.type === 'group' ? value && (o._id + S + value) || o._id : value);
+                        break;
                     case "cursor":
                         s.cursor = value;
                         break;
@@ -1333,7 +1337,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         res.type = "group";
         res.canvas = res.node;
         res.top = res.bottom = null;
-        id && el.setAttribute('class', ['red', id, res.id].join('-'));
+        id && el.setAttribute('class', res._id = ['red', id, res.id].join('-'));
         return res;
     };
 

--- a/source/raphael.vml.js
+++ b/source/raphael.vml.js
@@ -196,6 +196,10 @@ window.Raphael && window.Raphael.vml && function(R) {
         params.target && (node.target = params.target);
         params.cursor && (s.cursor = params.cursor);
         "blur" in params && o.blur(params.blur);
+
+        ("class" in params) && (node.className = isGroup ?
+            params["class"] && (o._id + S + params["class"]) || o._id : ("rvml " + params["class"]));
+
         if (params.path && o.type == "path" || newpath) {
             node.path = path2vml(~Str(a.path).toLowerCase().indexOf("r") ? R._pathToAbsolute(a.path) : a.path);
             if (o.type == "image") {
@@ -941,7 +945,7 @@ window.Raphael && window.Raphael.vml && function(R) {
 
         el.style.cssText = cssDot;
 
-        id && (el.className = ['red', id, p.id].join('-'));
+        id && (el.className = (p._id = ['red', id, p.id].join('-')));
         (group || vml).canvas.appendChild(el);
 
         p.type = 'group';


### PR DESCRIPTION
`Element.attr('class', 'your-cl-ass-name');`

The changes were in both VML and SVG renderer where within setFillAndStroke check for class parameter and apply to element. For VML, it is applied as className property of node. The only extra computation comes in case where class is applied to group. The default class of the group is also retained.

The only change in core.js is to add class as part of availableAttrs object.

Tested on local Mac Safari, Chrome and IE 6, IE 7, IE 8 on XP + IE 9 on Windows 7. Also tested by adding static style to page and see if it affects the element whose class is set - both in SVG and VML.
