### PR TITLE
RedRaphael whenever required by a library in a non AMD fashion and AMD b...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
                 svgorvmlRegex = /\.(svg|vml|canvas)\.js/,
                 closureRegex = /window\.Raphael.*\(R\)\s*\{/,
                 closureEndRegex = /\}\(window\.Raphael\);\s*$/,
-                exposeRegex = /(\r?\n\s*\/\/\s*EXPOSE(?:\r|\n|.)*\}\)\);)/;
+                exposeRegex = /(\r?\n\s*\/\/\s*EXPOSE(?:\r|\n|.)*\)\);)/;
 
             // Concatenate src
             src.forEach(function(path) {

--- a/source/eve/eve.js
+++ b/source/eve/eve.js
@@ -1,11 +1,11 @@
 // Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@
 // │ Author Dmitry Baranovskiy (http://dmitry.baranovskiy.com/) │ \\
 // └────────────────────────────────────────────────────────────┘ \\
 
-(function (glob) {
+(function (glob, optOutModulePattern) {
     var version = "0.4.2",
         has = "hasOwnProperty",
         separator = /[\.\/]/,
@@ -149,7 +149,7 @@
         }
         return out;
     };
-    
+
     /*\
      * eve.on
      [ method ]
@@ -164,7 +164,7 @@
      - name (string) name of the event, dot (`.`) or slash (`/`) separated, with optional wildcards
      - f (function) event handler function
      **
-     = (function) returned function accepts a single numeric parameter that represents z-index of the handler. It is an optional feature and only used when you need to ensure that some subset of handlers will be invoked in a given order, despite of the order of assignment. 
+     = (function) returned function accepts a single numeric parameter that represents z-index of the handler. It is an optional feature and only used when you need to ensure that some subset of handlers will be invoked in a given order, despite of the order of assignment.
      > Example:
      | eve.on("mouse", eatIt)(2);
      | eve.on("mouse", scream);
@@ -367,5 +367,5 @@
     eve.toString = function () {
         return "You are running Eve " + version;
     };
-    (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define != "undefined" ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
-})(this);
+    (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (!optOutModulePattern && typeof define != "undefined" ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
+})(this, (typeof optOutModulePattern != "undefined" ? optOutModulePattern : false));

--- a/source/fusioncharts-wrapper-template.js
+++ b/source/fusioncharts-wrapper-template.js
@@ -9,7 +9,8 @@ window.FusionCharts && window.FusionCharts.register('module', ['private', 'vendo
         lib = global.hcLib,
         someRaphael = window.Raphael,
         eve,
-        RedRaphael;
+        RedRaphael,
+        optOutModulePattern = true;
 
 
     (function () {

--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -8,9 +8,9 @@
  *
  * Licensed under the MIT license.
  */
-(function (glob, factory) {
+(function (glob, factory, optOutModulePattern) {
     // AMD support
-    if (typeof define === "function" && define.amd) {
+    if (!optOutModulePattern && typeof define === "function" && define.amd) {
         // Define as an anonymous module
         define(["eve"], function( eve ) {
             return factory(glob, eve);
@@ -6397,4 +6397,4 @@
     oldRaphael.was ? (g.win.Raphael = R) : (Raphael = R);
 
     return R;
-}));
+}, (typeof optOutModulePattern != "undefined" ? optOutModulePattern : false)));


### PR DESCRIPTION
...ased module loader is used, RedRaphael is not itegrated properly.

Whenever a module loader is used in the page and RedRaphael detects it, RedRaphael defines itself in modules.
But if the library integrating RedRaphael doesn't require the RedRaphael modules in the module definition fashion, RedRaphael will never be integrated.

Fix is to use a flag based approach to prevent RedRaphael from defining itslef into modules.

The flag used is `optOutModuleLoading`.

Changes are also made in GruntFile.js `build` task to accomodate the changes where the SVG and VML modules are added before `//EXPOSE` line, the regex to determine
that is rectified.
