### PR TITLE
Replaced global variable Raphael with local reference R in arrow-end att...

### DIFF
--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -406,7 +406,7 @@ window.Raphael && window.Raphael.svg && function(R) {
                 attr = {};
                 attr["marker-" + se] = "url('" + R._url + "#" + markerId + "')";
                 if (to || from) {
-                    attr.d = Raphael.getSubpath(attrs.path, from, to);
+                    attr.d = R.getSubpath(attrs.path, from, to);
                 }
                 $(node, attr);
                 o._.arrows[se + "Path"] = pathId;
@@ -423,7 +423,7 @@ window.Raphael && window.Raphael.svg && function(R) {
                     to = R.getTotalLength(attrs.path) - (o._.arrows.enddx * stroke || 0);
                 }
                 o._.arrows[se + "Path"] && $(node, {
-                    d: Raphael.getSubpath(attrs.path, from, to)
+                    d: R.getSubpath(attrs.path, from, to)
                 });
                 delete o._.arrows[se + "Path"];
                 delete o._.arrows[se + "Marker"];


### PR DESCRIPTION
## raphael.svg.js

Global variable 'Raphael' was being used in computing attribute for arrow-end for path.
This was throwing error.

Replaced global 'Raphael' with 'R' variable which is a local reference to Raphael object.
