### PR TITLE
Node 0.8 was stalling travis builds. Updated travis.yml to remove Node 0...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: node_js
 
 node_js:
  - "0.11"
- - "0.8"
 
 branches:
  only:
-  "master"
+ - "master"
+ - "develop"
 
 script: "grunt"
 


### PR DESCRIPTION
Node 0.8 was stalling travis builds. Updated travis.yml to remove Node 0.8 build environment.
- Erring log: https://s3.amazonaws.com/archive.travis-ci.org/jobs/34187132/log.txt
- Example of erring job: https://travis-ci.org/fusioncharts/redraphael/jobs/34187132

Seems like the issue lies with lack of support for grunt with this version of NodeJS. The log shows:

``` terminal
Error: No compatible version found: grunt@'^0.4.2'
```

PS: Also added build trigger for commit to `develop` branch.
