### PR TITLE
Fix for Line Charts does not render in Chrome when stroke dash length is zero

### DIFF
--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -481,7 +481,7 @@ window.Raphael && window.Raphael.svg && function(R) {
             calculatedValues = [];
             while (i--) {
                 calculatedValues[i] = (value[i] * widthFactor + ((i % 2) ? 1 : -1) * butt) || value[i];
-                calculatedValues[i] < 0 && [calculatedValues[i]=Math.abs(calculatedValues[i])];
+                calculatedValues[i] < 0 && (calculatedValues[i] = abs(calculatedValues[i]));
             }
 
             if (R.is(value, 'array')) {

--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -481,7 +481,7 @@ window.Raphael && window.Raphael.svg && function(R) {
             calculatedValues = [];
             while (i--) {
                 calculatedValues[i] = (value[i] * widthFactor + ((i % 2) ? 1 : -1) * butt) || value[i];
-                calculatedValues[i] < 0 && (calculatedValues[i] = 0);
+                calculatedValues[i] < 0 && [calculatedValues[i]=Math.abs(calculatedValues[i])];
             }
 
             if (R.is(value, 'array')) {


### PR DESCRIPTION
Fix for Line Charts does not render in Chrome when stroke dash length is zero
    
    - The svg file was hardcoding the stroke dash length zero whenever the stroke dash expression
    - calculated a negative value.This fix takes the absolute value of the stroke dash expression
    - so that Chrome can render the the chart whenever the stroke dash length is negative