### PR TITLE
Fix dashed-line dash length.

### DIFF
--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -480,8 +480,8 @@ window.Raphael && window.Raphael.svg && function(R) {
 
             calculatedValues = [];
             while (i--) {
-                calculatedValues[i] = (value[i] * widthFactor + ((i % 2) ? 1 : -1) * butt) || value[i];
-                calculatedValues[i] < 0 && (calculatedValues[i] = abs(calculatedValues[i]));
+                calculatedValues[i] = (value[i] * widthFactor + ((i % 2) ? 1 : -1) * butt);
+                calculatedValues[i] <= 0 && (calculatedValues[i] = 0.01);
             }
 
             if (R.is(value, 'array')) {


### PR DESCRIPTION
- Since, stroke-linecap="round" is used, "lineDashLen" cannot be <= "lineThickness" as linecap depends on "lineThickness".
If condition arises when "lineDashLen" <= "lineThickness", the "lineDashLen" will be always equals to "lineThickness".