### PR TITLE
Fix issue of "dash-array" value NaN for "stroke" value "none".

### DIFF
--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -467,7 +467,7 @@ window.Raphael && window.Raphael.svg && function(R) {
             widthFactor;
 
         value = predefValue || ((value !== undefined) && [].concat(value));
-        if (value) {
+        if (value && (value[0] !== "none")) {
 
             width = o.attrs["stroke-width"] || 1;
             butt = {
@@ -482,6 +482,9 @@ window.Raphael && window.Raphael.svg && function(R) {
             while (i--) {
                 calculatedValues[i] = (value[i] * widthFactor + ((i % 2) ? 1 : -1) * butt);
                 calculatedValues[i] <= 0 && (calculatedValues[i] = 0.01);
+                if (isNaN(calculatedValues[i])) {
+                   calculatedValues[i] = 0;
+               }
             }
 
             if (R.is(value, 'array')) {
@@ -511,7 +514,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         // Convert all the &lt; and &gt; to < and > and if there is any <br/> tag in between &lt; and &gt;
         // then converting them into <<br/> and ><br/> respectively.
         if (params && params.text) {
-            params.text = params.text.replace(/&lt;/g, "<").replace(/&gt;/g, ">")  
+            params.text = params.text.replace(/&lt;/g, "<").replace(/&gt;/g, ">")
                 .replace(/&<br\/>lt;|&l<br\/>t;|&lt<br\/>;/g, "<<br/>")
                 .replace(/&<br\/>gt;|&g<br\/>t;|&gt<br\/>;/g, "><br/>");
         }


### PR DESCRIPTION
Fix issue of "dash-array" value NaN for "stroke" value "none".
- Checks for "none" value and sets "dash-array" attributes accordingly.
- If any value in "dash-array", after calculation, is found NaN, it is converted to "0".