### PR TITLE
Fix issue of unwanted image for blank src of image element in Chrome.

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -3855,8 +3855,8 @@
                 !drag.length && R.dragmove(dragMove).dragend(dragUp);
             }
             !drag.length && R.mousemove(dragMove).mouseup(dragUp);
-            
-            
+
+
             drag.push({
                 el: this,
                 move_scope: move_scope,
@@ -3879,7 +3879,7 @@
             this.dragstart(start);
         }
         this.mousedown(start);
-        
+
         return this;
     };
 
@@ -4164,7 +4164,7 @@
             args = arguments,
             group = lastArgIfGroup(args, true),
             attrs = serializeArgs(args,
-                "src", "about:blank",
+                "src", !!navigator.userAgent.match(/Chrome/ig) ? "" : "about:blank",
                 "x", 0,
                 "y", 0,
                 "width", 0,


### PR DESCRIPTION
- Chrome sets a default unwanted image for src "about:blank" when src is provided blank.
- Thus, checks for Chrome browser and sets src blank("") for chrome browser for image element and "about:blank" for other browsers.