### PR TITLE
Fix js error in blank arguments for custom attributes and typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Raphael.define({
 - Global mouseUp tracking using el.mouseup(fn, scope, true);
 - Support for customizable dash-style
 - Support for attribute `key` in attr.* events
-- upport for Raphael.ca for common customAttributes across papers
+- Support for Raphael.ca for common customAttributes across papers
 - Support for text-bound: [stroke, fill, stroke-width, padding, corner-radius, dash-style] on texts
 - Support for opacity in fill color (rgba, hsla, etc) for elements
 - Support for `visibility` on elements via attr

--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -6574,7 +6574,7 @@
                 // Check if namesake ca exists and apply it
                 if (element.ca[name]) {
                     R._lastArgIfGroup(args, true); // purge group
-                    element.attr(name, arraySlice.call(args))
+                    args.length && element.attr(name, arraySlice.call(args))
                 }
             }
 


### PR DESCRIPTION
- Slice operation is valid for arguments with valid cardinal number
- Fix the js error due to it
- Fix a typo error