### PR TITLE
Applying attr for the non-availableAnim attributes

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -5447,6 +5447,9 @@
                                 break;
                         }
                     }
+                    else {
+                        element.attr(attr, params[attr]);
+                    }
                 }
             var easing = params.easing,
             easyeasy = R.easing_formulas[easing];


### PR DESCRIPTION
In regard to [issue](https://github.com/fusioncharts/redraphael/issues/65), an else part might be a solution.

If its not animatable, applying directly as an attribute.