### PR TITLE
Fix for the followers to follow the leader's repeated transformations.

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -2141,9 +2141,6 @@
     \*/
     var pathDimensions = R.pathBBox = function(path) {
         var pth = paths(path);
-        if (pth.bbox) {
-            return pth.bbox;
-        }
         if (!path) {
             return {
                 x: 0,


### PR DESCRIPTION
In reference to the [issue](https://github.com/fusioncharts/redraphael/issues/69), this might be a probable fix.
  - Update the bbox calculations for the leader element.
  - Recalculating the bbox results helps the follower get the latest track of its leader positions post-transformation.
  - Although, there is a slight sacrifice on the part of performance if repeatedely elements being created(transformed) at same co-ordinate. e.g. creating 1000 texts at same coordinate slows down the performance by 400ms.