### PR TITLE
Apply changes of leader element amongst the follower elements

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -139,6 +139,8 @@
         objectToStr = "[object Object]",
         arraySlice = Array.prototype.slice,
         arraySplice = Array.prototype.splice,
+        arrayShift = Array.prototype.shift,
+        arrayPop = Array.prototype.pop,
         hasPrototypeBug = (function () {
             var a = function () {};
             return a.hasOwnProperty("prototype");

--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -864,6 +864,25 @@ window.Raphael && window.Raphael.svg && function(R) {
         (o.type === 'text') && tuneText(o, params);
         s.visibility = vis;
     },
+    /*
+     * Keeps the follower element in sync with the leaders.
+     * First and second arguments represents the context(element) and the 
+     name of the callBack function respectively.
+     * The callBack is invoked for indivual follower Element with the rest of
+     arguments.
+    */
+    updateFollowers = R._updateFollowers = function () {
+        var i,
+            ii,
+            followerElem,
+            args = arguments,
+            o = arrayShift.call(args),
+            fnName = arrayShift.call(args);
+        for (i = 0, ii = o.followers.length; i < ii; i++) {
+            followerElem = o.followers[i].el;
+            followerElem[fnName].apply(followerElem, args);
+        }
+    },
     leading = 1.2,
     tuneText = function(el, params) {
         if (el.type != "text" || !(params[has]("text") || params[has]("font") ||

--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -1072,6 +1072,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         if (o.removed) {
             return o;
         }
+        updateFollowers(o, 'rotate', deg, cx, cy);
         deg = Str(deg).split(separator);
         if (deg.length - 1) {
             cx = toFloat(deg[1]);
@@ -1094,6 +1095,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         if (o.removed) {
             return o;
         }
+        updateFollowers(o, 'scale', sx, sy, cx, cy);
         sx = Str(sx).split(separator);
         if (sx.length - 1) {
             sy = toFloat(sx[1]);
@@ -1117,6 +1119,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         if (o.removed) {
             return o;
         }
+        updateFollowers(o, 'translate', dx, dy);
         dx = Str(dx).split(separator);
         if (dx.length - 1) {
             dy = toFloat(dx[1]);
@@ -1157,12 +1160,14 @@ window.Raphael && window.Raphael.svg && function(R) {
 
     elproto.hide = function() {
         var o = this;
+        updateFollowers(o, 'hide');
         !o.removed && o.paper.safari(o.node.style.display = "none");
         return o;
     };
 
     elproto.show = function() {
         var o = this;
+        updateFollowers(o, 'show');
         !o.removed && o.paper.safari(o.node.style.display = E);
         return o;
     };

--- a/source/raphael.vml.js
+++ b/source/raphael.vml.js
@@ -677,8 +677,9 @@ window.Raphael && window.Raphael.vml && function(R) {
         return this;
     };
     elproto.rotate = function(deg, cx, cy) {
-        if (this.removed) {
-            return this;
+        var o = this;
+        if (o.removed) {
+            return o;
         }
         updateFollowers(o, 'rotate', deg, cx, cy);
         if (deg == null) {
@@ -692,17 +693,18 @@ window.Raphael && window.Raphael.vml && function(R) {
         deg = toFloat(deg[0]);
         (cy == null) && (cx = cy);
         if (cx == null || cy == null) {
-            var bbox = this.getBBox(1);
+            var bbox = o.getBBox(1);
             cx = bbox.x + bbox.width / 2;
             cy = bbox.y + bbox.height / 2;
         }
-        this._.dirtyT = 1;
-        this.transform(this._.transform.concat([["r", deg, cx, cy]]));
-        return this;
+        o._.dirtyT = 1;
+        o.transform(o._.transform.concat([["r", deg, cx, cy]]));
+        return o;
     };
     elproto.translate = function(dx, dy) {
-        if (this.removed) {
-            return this;
+        var o = this;
+        if (o.removed) {
+            return o;
         }
         updateFollowers(o, 'translate', dx, dy);
         dx = Str(dx).split(separator);
@@ -711,16 +713,17 @@ window.Raphael && window.Raphael.vml && function(R) {
         }
         dx = toFloat(dx[0]) || 0;
         dy = +dy || 0;
-        if (this._.bbox) {
-            this._.bbox.x += dx;
-            this._.bbox.y += dy;
+        if (o._.bbox) {
+            o._.bbox.x += dx;
+            o._.bbox.y += dy;
         }
-        this.transform(this._.transform.concat([["t", dx, dy]]));
-        return this;
+        o.transform(o._.transform.concat([["t", dx, dy]]));
+        return o;
     };
     elproto.scale = function(sx, sy, cx, cy) {
-        if (this.removed) {
-            return this;
+        var o = this;
+        if (o.removed) {
+            return o;
         }
         updateFollowers(o, 'scale', sx, sy, cx, cy);
         sx = Str(sx).split(separator);
@@ -735,14 +738,14 @@ window.Raphael && window.Raphael.vml && function(R) {
         (sy == null) && (sy = sx);
         (cy == null) && (cx = cy);
         if (cx == null || cy == null) {
-            var bbox = this.getBBox(1);
+            var bbox = o.getBBox(1);
         }
         cx = cx == null ? bbox.x + bbox.width / 2 : cx;
         cy = cy == null ? bbox.y + bbox.height / 2 : cy;
 
-        this.transform(this._.transform.concat([["s", sx, sy, cx, cy]]));
-        this._.dirtyT = 1;
-        return this;
+        o.transform(o._.transform.concat([["s", sx, sy, cx, cy]]));
+        o._.dirtyT = 1;
+        return o;
     };
     elproto.hide = function(soft) {
         var o = this;
@@ -758,14 +761,15 @@ window.Raphael && window.Raphael.vml && function(R) {
         return o;
     };
     elproto._getBBox = function() {
-        if (this.removed) {
+        var o = this;
+        if (o.removed) {
             return {};
         }
         return {
-            x: this.X + (this.bbx || 0) - this.W / 2,
-            y: this.Y + (this.bby || 0) - this.H / 2,
-            width: this.W,
-            height: this.H
+            x: o.X + (o.bbx || 0) - o.W / 2,
+            y: o.Y + (o.bby || 0) - o.H / 2,
+            width: o.W,
+            height: o.H
         };
     };
     elproto.remove = function() {

--- a/source/raphael.vml.js
+++ b/source/raphael.vml.js
@@ -680,6 +680,7 @@ window.Raphael && window.Raphael.vml && function(R) {
         if (this.removed) {
             return this;
         }
+        updateFollowers(o, 'rotate', deg, cx, cy);
         if (deg == null) {
             return;
         }
@@ -703,6 +704,7 @@ window.Raphael && window.Raphael.vml && function(R) {
         if (this.removed) {
             return this;
         }
+        updateFollowers(o, 'translate', dx, dy);
         dx = Str(dx).split(separator);
         if (dx.length - 1) {
             dy = toFloat(dx[1]);
@@ -720,6 +722,7 @@ window.Raphael && window.Raphael.vml && function(R) {
         if (this.removed) {
             return this;
         }
+        updateFollowers(o, 'scale', sx, sy, cx, cy);
         sx = Str(sx).split(separator);
         if (sx.length - 1) {
             sy = toFloat(sx[1]);
@@ -743,12 +746,14 @@ window.Raphael && window.Raphael.vml && function(R) {
     };
     elproto.hide = function(soft) {
         var o = this;
+        updateFollowers(o, 'hide', soft);
         !o.removed && (o.node.style.display = "none");
         return o;
     };
 
     elproto.show = function(soft) {
         var o = this;
+        updateFollowers(o, 'show', soft);
         !o.removed && (o.node.style.display = E);
         return o;
     };

--- a/source/raphael.vml.js
+++ b/source/raphael.vml.js
@@ -483,6 +483,25 @@ window.Raphael && window.Raphael.vml && function(R) {
         }
     // res.paper.canvas.style.display = E;
     },
+    /*
+     * Keeps the follower element in sync with the leaders.
+     * First and second arguments represents the context(element) and the 
+     name of the callBack function respectively.
+     * The callBack is invoked for indivual follower Element with the rest of
+     arguments.
+    */
+    updateFollowers = R._updateFollowers = function () {
+        var i,
+            ii,
+            followerElem,
+            args = arguments,
+            o = arrayShift.call(args),
+            fnName = arrayShift.call(args);
+        for (i = 0, ii = o.followers.length; i < ii; i++) {
+            followerElem = o.followers[i].el;
+            followerElem[fnName].apply(followerElem, args);
+        }
+    },
     addGradientFill = function(o, gradient, fill) {
         o.attrs = o.attrs || {};
         var attrs = o.attrs,


### PR DESCRIPTION
_In Reference to the [issue](https://github.com/fusioncharts/redraphael/issues/69)_, this might be a probable fix:

**Add a generalised updateFollowers function to keep the followers in sync with the leader in both SVG and VML supported browsers**
    
 - updateFollowers takes the context, callBack function name, and the other required arguments for the callback.
 - context(i.e. the element here) and the callBack nameSpaces(a String) are trimmed(shifted) off the main argument object.
 - Every individual follower element contained in the leader element is made to 
invoke the callback function blindly with remaining arguments.

**Invoke the updateFollowers function for show, hide, scale, rotate and translate of the leader elements in svg and VML as well.** 

  - updateFollowers stays a generalised function which accepts the context and callBack name to be invoked by individual follower elements.
  - e.g. hiding/ showing a text element having a text-bound now also hides/shows the text-bounding rectangular element in both svg and VML supported browsers.