### PR TITLE
Extend support for easing animation in paper element

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -4333,9 +4333,9 @@
     function paperAnimator(paper, duration, start, end, rule, effect, callback) {
         var iterations = (duration / UNIT_INTERVAL),
             diff = (end - start),
+            ef = R.easing_formulas,
             incrementArr = (function () {
                 var i = 0,
-                    ef = R.easing_formulas,
                     arr = [];
                 for (; i < duration; i += UNIT_INTERVAL) {
                     arr.push(((ef[effect || 'linear'](i / duration)) * diff));
@@ -4358,6 +4358,7 @@
                     setValue,
                     val,
                     value,
+                    weightedProgress,
                     attr = {},
                     reduce = false;
 
@@ -4367,13 +4368,14 @@
                     }
                     progress = timestamp - startTime;
 
+                    weightedProgress = ef[effect || 'linear'](progress / duration);
                     diff = Math.abs(start - end);
 
                     reduce = (start - end) < 0 ? false : true;
 
                     setValue = reduce ?
-                        (Math.max(start - (progress * (diff / duration)), end)) :
-                        (Math.min(start + (progress * (diff / duration)), end));
+                        (Math.max(start - (weightedProgress * diff), end)) :
+                        (Math.min(start + (weightedProgress * diff), end));
 
                     attr[rule] = setValue;
                     paper.setDimension(attr);

--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -4333,21 +4333,15 @@
     function paperAnimator(paper, duration, start, end, rule, effect, callback) {
         var iterations = (duration / UNIT_INTERVAL),
             diff = (end - start),
-            effects = {
-                linear: function (diff, iterations) {
-                    var
-                        returnArr = [],
-                        increment = (diff / iterations),
-                        i = 0;
-
-                    for (;i < iterations; i += 1) {
-                        returnArr[i] = increment * (i + 1);
-                    }
-
-                    return returnArr;
+            incrementArr = (function () {
+                var i = 0,
+                    ef = R.easing_formulas,
+                    arr = [];
+                for (; i < duration; i += UNIT_INTERVAL) {
+                    arr.push(((ef[effect || 'linear'](i / duration)) * diff));
                 }
-            },
-            incrementArr = effects[effect || 'linear'](diff, iterations),
+                return arr;
+            })(),
             counter = 0,
             startTime,
             progress,

--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -4472,8 +4472,6 @@
             rule,
             attr = {};
 
-        // For now it supports only 'linear' animation style
-        effect = 'linear';
 
         if (duration < UNIT_INTERVAL) {
             // If the duration of animation is less than the


### PR DESCRIPTION
In reference to the [issue](https://github.com/fusioncharts/redraphael/issues/71), 

Instead of attaching equal increment for the differential calculations, _R.easing_formulas_ attaches a weightage factor. This factor is dependent on the easing effect. 

It takes the progress proportion(`progress / duration`) and based on the effects specified, computes the [functional value](http://easings.net/#) for that ratio. Thus all kinds of animation easing effects are now supported following the easing equations even for the paper element.

Creating a PR for the same. Please validate.