### PR TITLE
RED-8859: Fixed issue of touchAction in touch devices

### DIFF
--- a/source/raphael.core.js
+++ b/source/raphael.core.js
@@ -168,6 +168,7 @@ var loaded,
     isEdge = R.isEdge = /Edge/.test(navigator.userAgent),
     isIE11 = R.isIE11 = /trident/i.test(navigator.userAgent) &&
         /rv:11/i.test(navigator.userAgent) && !win.opera,
+    isIE10 = R.isIE10 = navigator.appVersion.indexOf('MSIE 10') !== -1,
     isFirefox = R.isFirefox = /Firefox/.test(navigator.userAgent),
     isWindows = R.isWindows = /Windows/.test(navigator.userAgent),
     mStr = 'm',

--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -2403,12 +2403,10 @@ export default function (R) {
             // '-ms-touch-action : none' permits no default touch behaviors in IE (10 and 11) browser
             // '-touch-action : none' permits no default touch behaviors in mozilla of windows
             if (supportsTouch) {
-                if (R.isEdge) {
-                    css += 'touch-action:none;';
-                } else if (R.isFirefox && R.isWindows) {
-                    css += 'touch-action:none;';
-                } else if (R.isIE11) {
+                if (R.isIE10) {
                     css += '-ms-touch-action:none;';
+                } else {
+                    css += 'touch-action:none;';
                 }
             }
             x = x || 0;


### PR DESCRIPTION
Due to touchAction css not setup , there was different behaviour in Android and IOS.
Fixed-  added a case for ie-10 as it requires a prefix '-ms' and no need to check for other browser type as it is a must css