### PR TITLE
FTV3-1201  JS Error on rendering Fusion Time Series Chart with consolidated Data Markers

### DIFF
--- a/source/raphael.svg.js
+++ b/source/raphael.svg.js
@@ -1810,6 +1810,8 @@ export default function (R) {
 
                         delete oldAttr.pathText;
 
+                        text = text.toString();
+
                         // If it is a new text applied
                         if (text !== oldAttr.text) {
                             textChanged = true;


### PR DESCRIPTION
Issue : https://fusioncharts.jira.com/browse/FTV3-1201

Fix : added the toString() method so that replace method will always receive input as string which will stop it to throw JS error .