### PR TITLE
Fixed : Support -2289 (Subscript and Superscript is not working with Firefox)

### DIFF
--- a/source/raphael.lib.js
+++ b/source/raphael.lib.js
@@ -377,4 +377,4 @@ var cacher = function (f, scope, postprocessor, key, maxCache, sharedCache, firs
     return cachedfunction;
 };
 
-export {merge, getArrayCopy, dashedAttr2CSSMap, loadRefImage, showRecursively, cacher};
+export {merge, getArrayCopy, dashedAttr2CSSMap, loadRefImage, showRecursively, cacher, isFirefox};


### PR DESCRIPTION
**RootCause** : The variable which define browser type as Firefox is not imported from file.

**Fix** : Import IsFirefox variable to use in another files.
